### PR TITLE
Attempt at well integrated monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
       "packages/react-router",
       "packages/react-router-native"
     ],
-    "nohoist": ["**/react-native", "**/react-native/**", "**/babel-jest", "**/babel-jest/**"]
+    "nohoist": ["**/react-native", "**/react-native/**"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,16 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "yarn workspaces run build",
     "clean": "git clean -fdX .",
-    "test": "node scripts/test.js"
+    "test": "yarn workspaces run test",
+    "test-single": "node ./scripts/test.js"
   },
-  "workspaces": [
-    "packages/react-router",
-    "packages/react-router-native"
-  ]
+  "workspaces": {
+    "packages": [
+      "packages/react-router",
+      "packages/react-router-native"
+    ],
+    "nohoist": ["**/react-native", "**/react-native/**", "**/babel-jest", "**/babel-jest/**"]
+  }
 }

--- a/packages/react-router-native/jest.config.js
+++ b/packages/react-router-native/jest.config.js
@@ -2,5 +2,9 @@ module.exports = {
   globals: {
     __DEV__: true
   },
-  testMatch: ["**/__tests__/**/*-test.js"]
+  "preset": "react-native",
+  testMatch: ["**/__tests__/**/*-test.js"],
+  transform: {
+    "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js",
+  },
 };

--- a/packages/react-router-native/modules/__tests__/index-test.js
+++ b/packages/react-router-native/modules/__tests__/index-test.js
@@ -5,6 +5,10 @@ import ReactRouterNative from "react-router-native";
 describe("react router native", () => {
   it("works", () => {
     let root = create(<ReactRouterNative message="hello world" />);
-    expect(root.toJSON()).toMatchInlineSnapshot();
+    expect(root.toJSON()).toMatchInlineSnapshot(`
+      <Text>
+        hello world
+      </Text>
+    `);
   });
 });

--- a/packages/react-router-native/rollup.config.js
+++ b/packages/react-router-native/rollup.config.js
@@ -13,7 +13,7 @@ export default [
       format: "esm",
       sourcemap: true
     },
-    external: ["react", "prop-types"],
+    external: ["react", "prop-types", "react-native"],
     plugins: [
       babel({
         exclude: /node_modules/,
@@ -41,12 +41,21 @@ export default [
       format: "esm",
       sourcemap: true
     },
-    external: ["react"],
+    external: ["react", "react-native"],
     plugins: [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
         sourceMaps: true,
+        presets: [
+          [
+            "module:metro-react-native-babel-preset",
+            {
+              disableImportExportTransform: true,
+              enableBabelRuntime: false
+            }
+          ]
+        ],
         plugins: [["@babel/plugin-transform-runtime", { useESModules: true }]]
       }),
       ignore(["prop-types"]),

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -13,5 +13,5 @@ const packages = target ? [target] : fs.readdirSync(packagesDir);
 
 packages.forEach(packageName => {
   process.chdir(path.join(packagesDir, packageName));
-  exec("yarn test");
+  exec("yarn run test");
 });


### PR DESCRIPTION
The Jest configuration was a bit awkward ended up combining a solution from searching [jest issues](https://github.com/facebook/jest/issues/6229#issuecomment-550974991) and the [jest react-native tutorial](https://jestjs.io/docs/en/tutorial-react-native#setup).

react-native doesn't link well from my experience, so adding to the `nohoist` prevents react-native from being hoisted to the root.

I couldn't get the production build to work correctly in react-router-native without the presets.